### PR TITLE
Proposal: Add OpenSSH Client to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=C.UTF-8 DEBIAN_FRONTEND=noninteractive
 RUN echo Starting. \
  && apt-get -q -y update \
  && apt-get -q -y install --no-install-recommends apcupsd dbus libapparmor1 libdbus-1-3 libexpat1 tzdata \
- && apt-get -q -y install postfix libsasl2-modules mailutils curl jq iputils-ping \
+ && apt-get -q -y install postfix libsasl2-modules mailutils curl jq iputils-ping openssh-client\
  && apt-get -q -y full-upgrade \
  && rm -rif /var/lib/apt/lists/* \
  && mkdir /opt/apcupsd \


### PR DESCRIPTION
👋🏻 Howdy :)

I'm using apcupsd-master-slave on a qnap nas (slave setup in container station), but `shutdown` is a real pain given these devices are running some heavily gutted linux with /sbin/poweroff being busybox.  

Would you consider adding openssh-client to the docker image, ✨ please✨ :) ?  
I'm currently building it with a custom Dockerfile, overriding the default, but I'd be surprised if I was the only one.

This would open up the door to use a custom shutdown command in apcupsd config such as:
```
SHUTDOWN=/usr/bin/ssh user@the-actual-host \
  -p 22 \
  -i /volume/mykey \
  -o StrictHostKeyChecking=no \
  -o UserKnownHostsFile=/dev/null \
  /sbin/poweroff
```

Thanks for considering :)